### PR TITLE
Add simplejson dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,5 @@ setup(
     platforms='any',
     packages=['sparqldataframe'],
     include_package_data=True,
-    install_requires=["pandas", "requests"],
+    install_requires=["pandas", "requests", "simplejson"],
 )


### PR DESCRIPTION
I did a fresh install of the library and noticed that simplejson was required but not installed. Adding it to the `setup.py` should solve this.